### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 edition = "2021"
 description = "wei run"
 documentation = "https://github.com/zuiyue-com/wei-run"
-homepage = "https://github.com/zuiyue-com/wei-run"
+repository = "https://github.com/zuiyue-com/wei-run"
 license = "MIT OR Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.